### PR TITLE
Add keywords: docblock, documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "keywords": [
         "php",
         "phpdoc",
+        "docblock",
         "dockblock",
-        "generator"
+        "generator",
+        "documentation"
     ],
     "activationEvents": [
         "onCommand:phpdoc-generator.generatePHPDoc"


### PR DESCRIPTION
Keywords was added, because the extension cannot be found.