### PR TITLE
Bugfix/14 - fix the definition of arguments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -40,8 +40,8 @@ function generateMethodDocBlock(matches) {
 
     if (methodDoc.hasParameters(matches)) {
         let parameters = methodDoc.getParameters(matches);
-        for (let parameter of parameters) {
-            docBlock += indent + ` * @param ${parameter.type} ${parameter.name}\r\n`;
+        for (let parameter of parameters) {            
+            docBlock += indent + ` * @param ${parameter.types.join('|')} ${parameter.name}\r\n`;
         }
         docBlock += indent + ` * \r\n`;
     }

--- a/lib/methoddoc.js
+++ b/lib/methoddoc.js
@@ -18,36 +18,43 @@ class MethodDoc {
 
             for (let typedParameter of typedParameters) {
                 let typedParameterParts = typedParameter.replace(/\s+/g, ' ').trim().split(" ");
+                
+                /** @var {string[]} types */
+                let types = [];
 
-                let type = 'mixed';
-                if (typedParameterParts.length == 2) {
-                    type = typedParameterParts[0];
-                } else if (typedParameterParts.length == 3) {
-                    type = matcher.getTypeFromString(typedParameterParts[2]);
-                } else if (typedParameterParts.length == 4) {
-                    type = typedParameterParts[0];
-                }
-                type = (type == 'int')
-                    ? 'integer'
-                    : type;
+                /** @var {string} variableName */
+                let variableName;
+                
+                if (typedParameterParts.length === 2) {
+                    // Example: string $value, ?array $value
+                    variableName = typedParameterParts[1];
+                    types = this.getTypesFromVariableType(typedParameterParts[0]);
+                } else if (typedParameterParts.length === 3) {
+                    // Examples: $value = 'value', $value = null, $value = []
+                    variableName = typedParameterParts[0];
+                    types = [matcher.getTypeFromString(typedParameterParts[2])];
+                } else if (typedParameterParts.length === 4) {
+                    // Examples: array $values = [] or array $values = null
+                    variableName = typedParameterParts[1];
+                    types = this.getTypesFromVariableType(typedParameterParts[0]);
 
-                let name = typedParameterParts[0];
-                if (typedParameterParts.length == 2) {
-                    name = typedParameterParts[1];
-                } else if (typedParameterParts.length == 3) {
-                    name = typedParameterParts[0];
-                } else if (typedParameterParts.length == 4) {
-                    name = typedParameterParts[1];
+                    if (types.length === 1 && typedParameterParts[3] === 'null') {
+                        types.push('null');
+                    }
+                } else {
+                    // Example: $value
+                    variableName = typedParameterParts[0];
+                    types = ['mixed'];
                 }
 
                 parameters.push({
-                    "type": type,
-                    "name": name,
+                    'types': types,
+                    'name': variableName,
                 });
             }
-
-            return parameters;
         }
+
+        return parameters;
     }
 
     static getReturn(matches) {
@@ -55,6 +62,20 @@ class MethodDoc {
             return matches[4];
         }
         return 'void';
+    }
+
+    /**
+     * Returns an array with types from the variable type.
+     * 
+     * @param  {string} value Contains one type or two types
+     * @return {string[]}
+     */
+    static getTypesFromVariableType(value)
+    {
+        return value.charAt(0) === '?'
+            ? [value.substring(1), 'null']
+            : [value]
+        ;
     }
 };
 exports.MethodDoc = MethodDoc;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "phpdoc-generator",
     "displayName": "PHPDoc Generator",
     "description": "PHPDoc Generator is a VSCode extension that generates a documentation block using a keyboard shortcut.",
+    "license": "MIT",
     "author": {
         "name": "Ron van der Heijden",
         "email": "me@ronvanderheijden.nl"


### PR DESCRIPTION
#14 
The result with arguments:
```php
    /**
     * @param array|null $name
     * 
     * @return void
     */
    public function nullAndType(array $name = null): ?float {
        return 0;
    }

    /**
     * @param int $name
     * 
     * @return int
     */
    public function oneType(int $name): int
    {
        return 1;
    }

    /**
     * @param string|null $name
     * 
     * @return void
     */
    public function typeOrNull(?string $name)
    {
        return 'mixed';
    }

    /**
     * @param string|null $name
     * 
     * @return void
     */
    public function typeWithTwoNull(?string $name = null)
    {
        return 'mixed';
    }

    /**
     * @param array $array
     * 
     * @return void
     */
    public function array($array = [])
    {
        # code...
    }

    /**
     * @param mixed $mixed
     * 
     * @return void
     */
    public function mixedOrUndefinedType($mixed): void
    {
        # code...
    }

    /**
     * @return void
     */
    public function noParameters()
    {
        # code...
    }
```